### PR TITLE
fix: fix S_REMOTE_CNT condition in DoNewOrder when UpdateStock

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -402,20 +402,24 @@ func (e *Executor) DoNewOrder(wId, dId, cId int, oEntryD time.Time, iIds []int, 
 		} else {
 			sQuantity += 91 - iQtys[0]
 		}
+		
+		S_REMOTE_CNT := (*stocks)[i].S_REMOTE_CNT
 
 		if iWids[i] != wId {
-			err = e.db.UpdateStock(
+			S_REMOTE_CNT += 1
+		}
+		
+		err = e.db.UpdateStock(
 				(*stocks)[i].S_I_ID,
 				iWids[1],
 				sQuantity,
 				(*stocks)[i].S_YTD + iQtys[i],
 				(*stocks)[i].S_ORDER_CNT + 1,
-				(*stocks)[i].S_REMOTE_CNT + 1,
+				S_REMOTE_CNT,
 			)
 
-			if err != nil {
-				return err
-			}
+		if err != nil {
+			return err
 		}
 
 		orderLines = append(orderLines, models.OrderLine{


### PR DESCRIPTION
Hi.
I just watch your code and I found that UpdateStock is caused when 
```
iWids[i] != wId 
```
this condition is true.
But [Py-TPCC](https://github.com/mongodb-labs/py-tpcc/blob/46f8f42a71626fc2057d2604ab9359ccf0395ba0/pytpcc/drivers/mongodbdriver.py#L726)
```
            if ol_supply_w_id != w_id:
                s_remote_cnt += 1
```
shows that every cases always perform UpdateStock.
So I change the logic when the condition is true, set S_REMOTE_CNT adding 1.